### PR TITLE
Fix env variable not used for director

### DIFF
--- a/rootfs/init/mysql-setup.sh
+++ b/rootfs/init/mysql-setup.sh
@@ -23,7 +23,7 @@ fi
 
 # Init Database if necessary
 echo "CREATE DATABASE IF NOT EXISTS $WEB_DB;" | $MYSQLCMD
-echo "CREATE DATABASE IF NOT EXISTS director;" | $MYSQLCMD
+echo "CREATE DATABASE IF NOT EXISTS $DIRECTOR_DB;" | $MYSQLCMD
 MYSQLCMD="$MYSQLCMD $WEB_DB"
 if [ "$(echo "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = \"$WEB_DB\";" | $MYSQLCMD -s)" -le 1 ]; then
   cat /icingaweb2/etc/schema/mysql.schema.sql | $MYSQLCMD


### PR DESCRIPTION
The environment variable `DIRECTOR_DB` wasn't used in the mysql setup.